### PR TITLE
Make build reproducible

### DIFF
--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -9,6 +9,8 @@ namespace :vox do
     args.with_defaults(project: 'puppet-agent')
     project = args[:project]
 
+    ENV['SOURCE_DATE_EPOCH'] = `git log -1 --format=%ct`.chomp
+
     abort 'You must provide a platform.' if args[:platform].nil? || args[:platform].empty?
     platform = args[:platform]
 


### PR DESCRIPTION
Set SOURCE_DATE_EPOCH in the environment to the date of the current commit in the git repository.  This variable is passed by vanagon to the build containers, where it will be used instead of the current date and time to produce artifacts in a reproducible way.