### PR TITLE
Release 7.36.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 7.36.1
+
+* Fix version in puppet component
+
 ## 7.36.0
 
 * Add conflicts/replaces metadata on puppet-agent

--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/puppet.git","ref":"ded3c994a5e137fd5c41b49b8cb64d51facdb82a"}
+{"url":"https://github.com/openvoxproject/puppet.git","ref":"1c2bec15713aab50a6c69b3f7f66a375ac13410f"}


### PR DESCRIPTION
I had neglected to bump the version in the https://github.com/openvoxproject/puppet repo, so help text showed the wrong version.