### PR TITLE
Provide puppet-agent on RPM

### DIFF
--- a/configs/projects/openvox-agent.rb
+++ b/configs/projects/openvox-agent.rb
@@ -93,7 +93,9 @@ project 'openvox-agent' do |proj|
   proj.license "See components"
   proj.vendor "Vox Pupuli <openvox@voxpupuli.org>"
   proj.homepage "https://voxpupuli.org"
-  proj.target_repo "openvox8"
+
+  major = proj.get_version.split('.').first
+  proj.target_repo "openvox#{major}"
 
   if platform.is_solaris?
     proj.identifier "voxpupuli.org"

--- a/configs/projects/openvox-agent.rb
+++ b/configs/projects/openvox-agent.rb
@@ -176,8 +176,13 @@ project 'openvox-agent' do |proj|
   end
 
   # make sure we can replace puppet-agent in place for the rename
-  proj.replaces 'puppet-agent'
+  proj.replaces 'puppet-agent', "< #{major.to_i + 1}"
   proj.conflicts 'puppet-agent'
+  if platform.is_rpm?
+    proj.provides 'puppet-agent', "= #{major}"
+  elsif platform.is_deb?
+    proj.provides 'puppet-agent', "(= #{major})"
+  end
 
   proj.timeout 7200 if platform.is_windows?
 end


### PR DESCRIPTION
This allows users to perform `dnf install puppet-agent` and get openvox-agent instead. It also means packages don't need to modify their dependencies. They probably still should, but this helps users migrate.

It also tightens the Obsoletes statement to include a version. rpmlint raises the unversioned-explicit-obsoletes warning on the old case. The Conflicts is kept unversioned, which is correct.

Currently untested, but submitting early for discussion.