### PR TITLE
Set paths back to PuppetLabs/Puppet on Windows

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -30,7 +30,7 @@ component "puppet" do |pkg, settings, platform|
     when "windows"
       # Note - this definition indicates that the file should be filtered out from the Wix
       # harvest. A corresponding service definition file is also required in resources/windows/wix
-      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\ruby.exe"
+      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:pl_company_id]}\\#{settings[:pl_product_id]}\\puppet\\bin\\ruby.exe"
     else
       fail "need to know where to put service files"
     end

--- a/configs/components/pxp-agent.rb
+++ b/configs/components/pxp-agent.rb
@@ -90,7 +90,7 @@ component "pxp-agent" do |pkg, settings, platform|
     when 'windows'
       # Note - this definition indicates that the file should be filtered out from the Wix
       # harvest. A corresponding service definition file is also required in resources/windows/wix
-      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:company_id]}\\#{settings[:product_id]}\\puppet\\bin\\nssm-pxp-agent.exe", init_system: servicetype
+      pkg.install_service "SourceDir\\#{settings[:base_dir]}\\#{settings[:pl_company_id]}\\#{settings[:pl_product_id]}\\puppet\\bin\\nssm-pxp-agent.exe", init_system: servicetype
     else
       fail "need to know where to put #{pkg.get_name} service files"
     end

--- a/configs/projects/openvox-agent.rb
+++ b/configs/projects/openvox-agent.rb
@@ -46,7 +46,7 @@ project 'openvox-agent' do |proj|
   # Project level settings our components will care about
   if platform.is_windows?
     proj.setting(:company_name, "Vox Pupuli")
-    proj.setting(:pl_company_name, "Vox Pupuli")
+    proj.setting(:pl_company_name, "PuppetLabs")
     proj.setting(:common_product_id, "PuppetInstaller")
     proj.setting(:puppet_service_name, "puppet")
     proj.setting(:upgrade_code, "2AD3D11C-61B3-4710-B106-B4FDEC5FA358")

--- a/resources/windows/wix/appdatafiles.wxs
+++ b/resources/windows/wix/appdatafiles.wxs
@@ -13,7 +13,7 @@
 
     <DirectoryRef Id="TARGETDIR">
       <Directory Id="CommonAppDataFolder" Name="CommonAppData">
-        <Directory Id="APPDATADIR" Name="VoxPupuli">
+        <Directory Id="APPDATADIR" Name="PuppetLabs">
           <Directory Id="pxpAgentDataFolder" Name="pxp-agent">
             <Directory Id="pxpAgentDataFolderVar" Name="var">
               <Directory Id="pxpAgentDataFolderLog" Name="log" />
@@ -47,7 +47,7 @@
     </DirectoryRef>
     <ComponentGroup Id="AppDataComponentGroup" >
       <Component
-        Id="VoxPupuliDataDir"
+        Id="PuppetLabsDataDir"
         Guid="EA55AEDB-3A9E-454E-9389-828341BEB4FC"
         Permanent="yes"
         Directory="APPDATADIR" >
@@ -250,7 +250,7 @@
         <File
           Id="HieraConf"
           KeyPath="yes"
-          Source="SourceDir\CommonAppDataFolder\VoxPupuli\puppet\etc\hiera.yaml" />
+          Source="SourceDir\CommonAppDataFolder\PuppetLabs\puppet\etc\hiera.yaml" />
         <Condition>NOT PUP_PREEXISTING_CODE_HIERA AND NOT PUP_PREEXISTING_CONF_HIERA</Condition>
       </Component>
       <Component
@@ -263,7 +263,7 @@
         <File
           Id="HieraProductionConf"
           KeyPath="yes"
-          Source="SourceDir\CommonAppDataFolder\VoxPupuli\code\environments\production\hiera.yaml" />
+          Source="SourceDir\CommonAppDataFolder\PuppetLabs\code\environments\production\hiera.yaml" />
         <Condition>NOT PUP_PREEXISTING_CODE_HIERA AND NOT PUP_PREEXISTING_CONF_HIERA</Condition>
       </Component>
       <Component
@@ -339,7 +339,7 @@
         <File
           Id="EnvironmentConf"
           KeyPath="yes"
-          Source="SourceDir\CommonAppDataFolder\VoxPupuli\code\environments\production\environment.conf" />
+          Source="SourceDir\CommonAppDataFolder\PuppetLabs\code\environments\production\environment.conf" />
       </Component>
       <Component
         Id="ManifestsDir"

--- a/resources/windows/wix/customactions.wxs.erb
+++ b/resources/windows/wix/customactions.wxs.erb
@@ -34,7 +34,7 @@ Function SetPropertyFromIni (keyName, propertyName, textToSearch)
 End Function
 Dim fso, wshShell, iniPath
 Set wshShell = CreateObject("WScript.Shell")
-iniPath = wshShell.ExpandEnvironmentStrings("%ALLUSERSPROFILE%\VoxPupuli\puppet\etc\puppet.conf")
+iniPath = wshShell.ExpandEnvironmentStrings("%ALLUSERSPROFILE%\PuppetLabs\puppet\etc\puppet.conf")
 Set fso = CreateObject("Scripting.FileSystemObject")
 If (fso.FileExists(iniPath)) Then
   Set iniFile = fso.OpenTextFile(iniPath, 1, false)
@@ -393,7 +393,7 @@ Function GetSDDL (Path)
   End If
 
   ' Win32_SecurityDescriptorHelper omits inheritance ID flag, and cacls omits O: and G: info
-  ' cacls output formatted like : C:\ProgramData\VoxPupuli\puppet "D:P(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)"
+  ' cacls output formatted like : C:\ProgramData\PuppetLabs\puppet "D:P(A;OICIID;FA;;;SY)(A;OICIID;FA;;;BA)"
   ' sddlString formatted like : O:SYG:SYD:AI(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)
   Dim caclsOutput : caclsOutput = ExecuteCommand(comspec & " /C " & cacls & "  """ & Path & """ /S")
 
@@ -481,10 +481,10 @@ Dim appDataPath : appDataPath = (shellApplication.Namespace(CommonAppData)).Self
 
 ' Due to PUP-6729, now that we can modify the DACL
 ' ensure admins and system have full control
-ResetPermissionsIfNotMatches appDataPath & "\VoxPupuli\puppet\etc", appDataPath & "\VoxPupuli\puppet", SDDL_DIR_INHERITED_ADMIN_ONLY_ADMINS_OWNER, True
-ResetPermissionsIfNotMatches appDataPath & "\VoxPupuli\code\environments", appDataPath & "\VoxPupuli\code", SDDL_DIR_INHERITED_ADMIN_ONLY, False
-ResetPermissionsIfNotMatches appDataPath & "\VoxPupuli\facter\facts.d", appDataPath & "\VoxPupuli\facter", SDDL_DIR_INHERITED_EVERYONE, False
-ResetPermissionsIfNotMatches appDataPath & "\VoxPupuli\pxp-agent\etc", appDataPath & "\VoxPupuli\pxp-agent", SDDL_DIR_INHERITED_ADMIN_ONLY, False
+ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\puppet\etc", appDataPath & "\PuppetLabs\puppet", SDDL_DIR_INHERITED_ADMIN_ONLY_ADMINS_OWNER, True
+ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\code\environments", appDataPath & "\PuppetLabs\code", SDDL_DIR_INHERITED_ADMIN_ONLY, False
+ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\facter\facts.d", appDataPath & "\PuppetLabs\facter", SDDL_DIR_INHERITED_EVERYONE, False
+ResetPermissionsIfNotMatches appDataPath & "\PuppetLabs\pxp-agent\etc", appDataPath & "\PuppetLabs\pxp-agent", SDDL_DIR_INHERITED_ADMIN_ONLY, False
       ]]>
     </CustomAction>
   </Fragment>

--- a/resources/windows/wix/directorylist.wxs.erb
+++ b/resources/windows/wix/directorylist.wxs.erb
@@ -3,8 +3,8 @@
   <Fragment>
     <DirectoryRef Id='TARGETDIR'>
       <Directory Id="<%= settings[:base_dir] %>" >
-        <Directory Id="<%= settings[:company_id] %>" Name="<%= settings[:pl_company_name] %>">
-          <Directory Id='INSTALLDIR' Name="<%= settings[:product_id] %>">
+        <Directory Id="<%= settings[:pl_company_id] %>" Name="<%= settings[:pl_company_name] %>">
+          <Directory Id='INSTALLDIR' Name="<%= settings[:pl_product_id] %>">
           <%= @platform.generate_service_bin_dirs(self.get_services, self) %>
           </Directory>
         </Directory>

--- a/resources/windows/wix/filter.xslt.erb
+++ b/resources/windows/wix/filter.xslt.erb
@@ -21,7 +21,7 @@
   <%- service_files = Array.new -%>
   <%- get_services.each do |service| -%>
 
-    <%- service_files << service.service_file.sub("SourceDir\\#{self.settings[:base_dir]}\\#{self.settings[:company_id]}\\#{self.settings[:product_id]}", "$(var.AppSourcePath)") -%>
+    <%- service_files << service.service_file.sub("SourceDir\\#{self.settings[:base_dir]}\\#{self.settings[:pl_company_id]}\\#{self.settings[:pl_product_id]}", "$(var.AppSourcePath)") -%>
   <%- end -%>
   <%- service_files.uniq.each do |service_file| -%>
     <xsl:template match="wix:Component[wix:File[@Source='<%= service_file %>']]" />

--- a/resources/windows/wix/properties.wxs.erb
+++ b/resources/windows/wix/properties.wxs.erb
@@ -186,7 +186,7 @@
       <RegistrySearch
         Id="RecallInstallDir"
         Root="HKLM"
-        Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:product_id] %>"
+        Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:pl_product_id] %>"
         Name="<%= settings[:RememberedInstallDirRegKey] %>"
         Type="raw"
         Win64="<%= settings[:win64] %>" />
@@ -196,7 +196,7 @@
       <RegistrySearch
         Id="RecallInstallDirx86"
         Root="HKLM"
-        Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:product_id] %>"
+        Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:pl_product_id] %>"
         Name="<%= settings[:RememberedInstallDirRegKey] %>"
         Type="raw"
         Win64="<%= settings[:win64] %>" />
@@ -204,8 +204,8 @@
 
     <!--
       Check if there is a pre-existing Hiera 3 format file in either:
-        1. C:\ProgramData\VoxPupuli\code
-        2. C:\ProgramData\VoxPupuli\puppet\etc
+        1. C:\ProgramData\PuppetLabs\code
+        2. C:\ProgramData\PuppetLabs\puppet\etc
       If either file exists, then we need to block the installation of the new format
       Hiera 5 default files.
       This Programdata directory is fixed, so its not influenced by a change in
@@ -213,12 +213,12 @@
       These properties are used in appdatafiles.wxs.
     -->
     <Property Id="PUP_PREEXISTING_CODE_HIERA">
-      <DirectorySearch Id="CheckCodeDir" Path="C:\ProgramData\VoxPupuli\code" Depth="0" AssignToProperty="yes">
+      <DirectorySearch Id="CheckCodeDir" Path="C:\ProgramData\PuppetLabs\code" Depth="0" AssignToProperty="yes">
         <FileSearch Id="CheckCodeHieraFile" Name="hiera.yaml" />
       </DirectorySearch>
     </Property>
     <Property Id="PUP_PREEXISTING_CONF_HIERA">
-      <DirectorySearch Id="CheckConfDir" Path="C:\ProgramData\VoxPupuli\puppet\etc" Depth="0" AssignToProperty="yes">
+      <DirectorySearch Id="CheckConfDir" Path="C:\ProgramData\PuppetLabs\puppet\etc" Depth="0" AssignToProperty="yes">
         <FileSearch Id="CheckConfHieraFile" Name="hiera.yaml" />
       </DirectorySearch>
     </Property>

--- a/resources/windows/wix/registryEntries.wxs.erb
+++ b/resources/windows/wix/registryEntries.wxs.erb
@@ -104,7 +104,7 @@
 
         <RegistryKey
           Root="HKLM"
-          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:product_id] %>"
+          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:pl_product_id] %>"
           ForceCreateOnInstall="yes" >
 
           <RegistryValue

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -13,7 +13,7 @@
         </Condition>
         <File Id="RubyExeAutomatic"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:pl_company_id] %>\<%= settings[:pl_product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -44,7 +44,7 @@
         </Condition>
         <File Id="RubyExeManual"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:pl_company_id] %>\<%= settings[:pl_product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerManual"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"
@@ -74,7 +74,7 @@
         </Condition>
         <File Id="RubyExeDisabled"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\ruby.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:pl_company_id] %>\<%= settings[:pl_product_id] %>\puppet\bin\ruby.exe" />
 
         <ServiceInstall Id="ServiceInstallerDisabled"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"

--- a/resources/windows/wix/service.pxp-agent.wxs.erb
+++ b/resources/windows/wix/service.pxp-agent.wxs.erb
@@ -9,7 +9,7 @@
         <CreateFolder />
         <File Id="NSSM_PXP_Agent"
               KeyPath="yes"
-              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:company_id] %>\<%= settings[:product_id] %>\puppet\bin\nssm-pxp-agent.exe" />
+              Source="SourceDir\<%= settings[:base_dir] %>\<%= settings[:pl_company_id] %>\<%= settings[:pl_product_id] %>\puppet\bin\nssm-pxp-agent.exe" />
 
         <ServiceInstall Id="PXPServiceInstaller"
                         Account="[PUPPET_AGENT_ACCOUNT_DOMAIN]\[PUPPET_AGENT_ACCOUNT_USER]"

--- a/resources/windows/wix/shortcuts.wxs.erb
+++ b/resources/windows/wix/shortcuts.wxs.erb
@@ -14,7 +14,7 @@
     <!-- Directory Definitions for Start Menu Shortcuts -->
     <DirectoryRef Id='TARGETDIR'>
       <Directory Id='ProgramMenuFolder'>
-        <Directory Id='PuppetShortcutDir' Name="<%= settings[:product_id] %>">
+        <Directory Id='PuppetShortcutDir' Name="<%= settings[:pl_product_id] %>">
           <Directory Id='PuppetShortcutDocumentationDir' Name="Documentation">
           </Directory>
         </Directory>
@@ -66,7 +66,7 @@
         <!-- This registry entry is required to be a keypath for this component -->
         <RegistryValue
           Root="HKCU"
-          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:product_id] %>"
+          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:pl_product_id] %>"
           Name="installed"
           Value="1"
           Type="integer"
@@ -124,7 +124,7 @@
           On="uninstall"/>
         <RegistryValue
           Root="HKCU"
-          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:product_id] %>\Documentation"
+          Key="SOFTWARE\<%= settings[:pl_company_name] %>\<%= settings[:pl_product_id] %>\Documentation"
           Name="installed"
           Value="1"
           Type="integer"


### PR DESCRIPTION
Changing the metadata unintentionally broke some things because changing company_id and product_id changes the paths where things live, where some modules expect things to be. This uses the pl_ versions of the settings as defined in puppet-runtime for things where we need the paths to remain.