### PR TITLE
(wip) Experimental gha workflow to run acceptance suite

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,0 +1,66 @@
+name: Acceptance Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  RUBY_VERSION: '3.3'
+
+jobs:
+  acceptance:
+    name: Acceptance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: vm-cluster
+        uses: jpartlow/kvm_automation_tooling
+        with:
+          os: ubuntu
+          os-version: 24.04
+          os-arch: x86_64
+          ruby-version: ${{ env.RUBY_VERSION }}
+          vms: |-
+            [
+              {
+                "role": "agent",
+                "count": 1
+              }
+            ]
+      - name: Install Ruby and Run Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          working-dir: acceptance
+          bundler-cache: true
+      - name: Construct hosts.yaml
+        working-dir: kvm_automation_tooling
+        env:
+          HOSTS_YAML: ${{ github.workspace }}/acceptance/hosts.yaml
+        run: |-
+          bundle exec bolt plan run \
+            kvm_automation_tooling::dev::generate_beaker_hosts_file \
+            --inventory terraform/instances/inventory.*.yaml \
+            --hosts_yaml="${HOSTS_YAML}"
+      - name: Run Beaker
+        working-dir: acceptance
+        run: |-
+          # TODO The ssh keyfile here is from the kvm_automation_tooling
+          # action...this should be cleaned up to be more discoverable
+          # or supplied as an input perhaps.
+          bundle exec beaker init --hosts hosts.yaml \
+            --preserve-hosts \always --keyfile ~/.ssh/ssh-id-test \
+            --pre-suite configure_type_defaults.rb \
+            --tests tests
+          # The provision step is still needed here, see notes in the
+          # kvm_automation_tooling/templates/beaker-hosts.yaml.epp
+          # template...
+          bundle exec beaker provision
+          bundle exec beaker exec

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,3 @@
 {
   :type => 'aio',
-  :post_suite => [
-    'teardown/common/099_Archive_Logs.rb',
-  ],
 }

--- a/acceptance/pre-suite/configure_type_defaults.rb
+++ b/acceptance/pre-suite/configure_type_defaults.rb
@@ -1,0 +1,8 @@
+# Ensures that the /root/.ssh/environment file is
+# set up with a path that includes /opt/puppetlabs/bin.
+# Normally this would be called as part of beaker-puppet
+# install steps, but we are installing openvox-agent outside
+# of beaker-puppet, since it doesn't handle openvox.
+test_name('configure root ssh environment path') do
+  configure_type_defaults_on(agents)
+end


### PR DESCRIPTION
in a nested libvirt cluster (with an exciting 1 vm...for two reasons, first, the test suite is minorly broken and will fail if two agents are executed (problem in
acceptance/tests/ensure_facter_command_can_be_executed.rb), and second, because the gha runner itself works fine to run beaker...)