### PR TITLE
Exp gha acceptance

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -16,6 +16,14 @@ jobs:
   acceptance:
     name: Acceptance Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+        os-version:
+          - '20.04'
+          - '22.04'
+          - '24.04'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,8 +31,8 @@ jobs:
       - id: vm-cluster
         uses: jpartlow/kvm_automation_tooling@main
         with:
-          os: ubuntu
-          os-version: 24.04
+          os: ${{ matrix.os }}
+          os-version: ${{ matrix.os-version }}
           os-arch: x86_64
           host-root-access: true
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,0 +1,69 @@
+name: Acceptance Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  RUBY_VERSION: '3.3'
+
+jobs:
+  acceptance:
+    name: Acceptance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: vm-cluster
+        uses: jpartlow/kvm_automation_tooling@main
+        with:
+          os: ubuntu
+          os-version: 24.04
+          os-arch: x86_64
+          host-root-access: true
+          ruby-version: ${{ env.RUBY_VERSION }}
+          vms: |-
+            [
+              {
+                "role": "agent",
+                "count": 1,
+                "cpus": 2,
+                "mem_mb": 4096
+              }
+            ]
+      - name: Install Ruby and Run Bundler
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          working-directory: acceptance
+          bundler-cache: true
+      - name: Construct hosts.yaml
+        working-directory: kvm_automation_tooling
+        env:
+          HOSTS_YAML: ${{ github.workspace }}/acceptance/hosts.yaml
+        run: |-
+          bundle exec bolt plan run \
+            kvm_automation_tooling::dev::generate_beaker_hosts_file \
+            --inventory terraform/instances/inventory.*.yaml \
+            hosts_yaml="${HOSTS_YAML}"
+      - name: Run Beaker
+        working-directory: acceptance
+        run: |-
+          # TODO The ssh keyfile here is from the kvm_automation_tooling
+          # action...this should be cleaned up to be more discoverable
+          # or supplied as an input perhaps.
+          bundle exec beaker init --hosts hosts.yaml \
+            --preserve-hosts always --keyfile ~/.ssh/ssh-id-test \
+            --pre-suite pre-suite/configure_type_defaults.rb \
+            --tests tests
+          # The provision step is still needed here, see notes in the
+          # kvm_automation_tooling/templates/beaker-hosts.yaml.epp
+          # template...
+          bundle exec beaker provision
+          bundle exec beaker exec

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,10 +1,36 @@
 name: Acceptance Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pre-release-build:
+        description: |-
+          (Pre-release Build) Whether to test unreleased version
+          packages from the artifacts server, or released packages
+          from the given collection.
+
+          If this is true, version must be a valid version, not
+          latest, and collection is ignored. The workflow will
+          download and install the matching openvox-agent package file
+          from the artifacts-url server.
+
+          If this is false, version and collection must match, and the
+          workflow will install the given openvox collection package
+          and then let the system package manager install the latest
+          or version package from the collection repository.
+        default: true
+        type: boolean
+      version:
+        description: '(Version) Package version to test. (required if Pre-release Build is true)'
+        type: string
+      collection:
+        description: '(Collection) OpenVox collection to use. (ignored if Pre-release Build is true)'
+        default: 'openvox8'
+        type: string
+      artifacts-url:
+        description: 'URL to the artifacts server. (used if Pre-release Build is true)'
+        default: 'https://s3.osuosl.org/openvox-artifacts'
+        type: string
 
 permissions:
   contents: read
@@ -21,6 +47,7 @@ jobs:
         os:
           - ubuntu
         os-version:
+          - '18.04'
           - '20.04'
           - '22.04'
           - '24.04'
@@ -36,6 +63,11 @@ jobs:
           os-arch: x86_64
           host-root-access: true
           ruby-version: ${{ env.RUBY_VERSION }}
+          install-openvox: true
+          openvox-version: ${{ github.event.inputs.version }}
+          openvox-collection: ${{ github.event.inputs.collection }}
+          openvox-released: ${{ ! github.event.inputs.pre-release-build }}
+          openvox-artifacts-url: ${{ github.event.inputs.artifacts-url }}
           vms: |-
             [
               {

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -51,12 +51,10 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu
-        os-version:
-          - '18.04'
-          - '20.04'
-          - '22.04'
-          - '24.04'
+          - [ubuntu, '18.04']
+          - [ubuntu, '20.04']
+          - [ubuntu, '22.04']
+          - [ubuntu, '24.04']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -64,8 +62,8 @@ jobs:
       - id: vm-cluster
         uses: jpartlow/kvm_automation_tooling@main
         with:
-          os: ${{ matrix.os }}
-          os-version: ${{ matrix.os-version }}
+          os: ${{ matrix.os[0] }}
+          os-version: ${{ matrix.os[1] }}
           os-arch: x86_64
           host-root-access: true
           ruby-version: ${{ env.RUBY_VERSION }}

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -1,4 +1,10 @@
-name: Acceptance Tests
+name: Beaker Acceptance Tests
+run-name: |-
+  Beaker acceptance tests for ${{ inputs.pre-release-build && 'pre-release' || 'release' }} package
+  ${{ (inputs.pre-release-build && inputs.version) ||
+      format(' collection: "{0}", version: "{1}" ',
+             inputs.collection,
+             ((inputs.version == '') && 'latest') || inputs.version) }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -66,7 +66,7 @@ jobs:
           install-openvox: true
           openvox-version: ${{ github.event.inputs.version }}
           openvox-collection: ${{ github.event.inputs.collection }}
-          openvox-released: ${{ ! github.event.inputs.pre-release-build }}
+          openvox-released: ${{ github.event.inputs.pre-release-build == 'false' }}
           openvox-artifacts-url: ${{ github.event.inputs.artifacts-url }}
           vms: |-
             [

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -55,6 +55,9 @@ jobs:
           - [ubuntu, '20.04']
           - [ubuntu, '22.04']
           - [ubuntu, '24.04']
+          - [debian, '10']
+          - [debian, '11']
+          - [debian, '12']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,4 +29,4 @@ jobs:
         run: |
           gem update --system --silent --no-document
           bundle install --jobs 4 --retry 3
-      - run: bundle exec rake ${{ matrix.check }}
+      - run: bundle exec rake ${{ matrix.check }} --trace

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ The Puppet Agent
  * License
  * Code Owners
  * Running Tests
+ * Github Actions
 
 Overview
 ---
@@ -144,3 +145,13 @@ See [CODEOWNERS](CODEOWNERS)
 Running Tests
 ---
 See [Acceptance README](acceptance/README.md)
+
+Github Actions
+---
+
+PR validation runs a pair of GHA jobs that check commit messages and
+run Rubocop (.github/workflows/checks.yml) via the Rakefile.
+
+There is also a manual acceptance GHA pipeline that runs the Beaker
+acceptance suite:
+See [GHA_ACCEPTANCE](acceptance/GHA_ACCEPTANCE.md)

--- a/Rakefile
+++ b/Rakefile
@@ -1,20 +1,24 @@
 require 'open3'
 
-RED = "\033[31m"
-GREEN = "\033[32m"
-RESET = "\033[0m"
+RED = "\033[31m".freeze
+GREEN = "\033[32m".freeze
+RESET = "\033[0m".freeze
 
+# Let's ignore rubocop here until such a time as we either muzzle it
+# or get these helpers more centralized and tested.
+# rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
 def run_command(cmd, silent: true, print_command: false, report_status: false)
-  puts "#{GREEN}Running #{cmd}#{RESET}" if print_command
+  cmd_string = cmd.is_a?(String) ? cmd : cmd.join(' ')
+  puts "#{GREEN}Running #{cmd_string}#{RESET}" if print_command
   output = ''
-  Open3.popen2e(cmd) do |_stdin, stdout_stderr, thread|
+  Open3.popen2e(*Array(cmd)) do |_stdin, stdout_stderr, thread|
     stdout_stderr.each do |line|
       puts line unless silent
       output += line
     end
     exitcode = thread.value.exitstatus
     unless exitcode.zero?
-      err = "#{RED}Command failed! Command: #{cmd}, Exit code: #{exitcode}"
+      err = "#{RED}Command failed! Command: #{cmd_string}, Exit code: #{exitcode}"
       # Print details if we were running silent
       err += "\nOutput:\n#{output}" if silent
       err += RESET
@@ -24,6 +28,7 @@ def run_command(cmd, silent: true, print_command: false, report_status: false)
   end
   output.chomp
 end
+# rubocop:enable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
 
 Dir.glob(File.join('tasks/**/*.rake')).each { |file| load file }
 

--- a/Rakefile
+++ b/Rakefile
@@ -49,45 +49,53 @@ end
 
 desc "verify that commit messages match CONTRIBUTING.md requirements"
 task(:commits) do
-  # This rake task looks at the summary from every commit from this branch not
-  # in the branch targeted for a PR. This is accomplished by using the
-  # TRAVIS_COMMIT_RANGE environment variable, which is present in travis CI and
-  # populated with the range of commits the PR contains. If not available, this
-  # falls back to `main..HEAD` as a next best bet as `main` is unlikely to
-  # ever be absent.
-  #
-  # When we move to GH actions, use `GITHUB_BASE_REF` to resolve the merge base
+  # Use `GITHUB_BASE_REF` to resolve the merge base
   # ref, which is the common ancestor between the base branch and PR. Then do
-  # git log for all of the commits in `HEAD` that are not in the base ref
-  #
-  #   baseref = %x{git merge-base HEAD $GITHUB_BASE_REF}
-  #   commits = "#{baseref}..HEAD"
-  commits = ENV['TRAVIS_COMMIT_RANGE'].nil? ? 'main..HEAD' : ENV['TRAVIS_COMMIT_RANGE'].sub(/\.\.\./, '..')
-  %x{git log --no-merges --pretty=%s #{commits}}.each_line do |commit_summary|
-    error_message=<<-HEREDOC
-\n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:\n \
-\n\t\t#{commit_summary}\n \
-\tThe commit summary (i.e. the first line of the commit message) should start with one of:\n  \
-\t\t(docs)\n \
-\t\t(maint)\n \
-\t\t(packaging)\n \
-\t\t(<ANY PUBLIC JIRA TICKET>)\n \
-\n\tThis test for the commit summary is case-insensitive.\n\n\n
+  # git log for all of the commits in `HEAD` that are not in the base ref.
+  github_base_ref = ENV.fetch('GITHUB_BASE_REF', 'main')
+  git_merge_base_cmd = ['git', 'merge-base', 'HEAD', github_base_ref]
+  baseref = run_command(git_merge_base_cmd)
+  commits = "#{baseref}..HEAD"
+  git_log_cmd = ['git', 'log', '--no-merges', '--pretty=%s', commits]
+  commit_lines = run_command(git_log_cmd, silent: false, print_command: true)
+
+  commit_lines.each_line do |commit_summary|
+    error_message = <<~HEREDOC
+      \n\n\n\tThis commit summary didn't match CONTRIBUTING.md guidelines:
+      \n\t\t#{commit_summary}
+      \tThe commit summary (i.e. the first line of the commit message) should start with one of:
+      \t\t(docs)
+      \t\t(maint)
+      \t\t(packaging)
+      \t\t(<gh-#>) (An existing github ticket ref)
+      \n\tThis test for the commit summary is case-insensitive.\n
     HEREDOC
 
-    if /^\((maint|doc|docs|packaging|pa-\d+)\)|revert|bumping|merge|promoting/i.match(commit_summary).nil?
-      ticket = commit_summary.match(/^\(([[:alpha:]]+-[[:digit:]]+)\).*/)
-      if ticket.nil?
-        raise error_message
-      else
-        require 'net/http'
-        require 'uri'
-        uri = URI.parse("https://tickets.puppetlabs.com/browse/#{ticket[1]}")
-        response = Net::HTTP.get_response(uri)
-        if response.code != "200"
-          raise error_message
-        end
-      end
+    commit_format_regex = /
+      ^\((?:maint|doc|docs|packaging|(([[:alpha:]]+)-(\d+)))\)|
+      revert|bumping|merge|promoting
+    /xi
+    match = commit_summary.match(commit_format_regex)
+    raise error_message if match.nil?
+
+    ticket = match[1]
+    next if ticket.nil?
+    project = match[2]
+    # Could be an old PUP- or other Jira, and while there is still a
+    # https://puppet.atlassian.net archive, determining that a
+    # particular ticket does not exist is more involved that getting a
+    # 200 on a call like https://puppet.atlassian.net/browse/PUP-1234
+    next if project != 'gh'
+    ticket_number = match[3]
+
+    require 'net/http'
+    require 'uri'
+    uri = URI.parse("https://github.com/openvoxproject/openvox-agent/issues/#{ticket_number}")
+    response = Net::HTTP.get_response(uri)
+    if response.code != "200"
+      ticket_error = "\t#{RED}Did not find a ticket matching #{ticket} at #{uri}#{RESET}\n\n"
+      raise error_message + ticket_error
     end
   end
+  puts "#{GREEN}All commit messages match the guidelines!#{RESET}"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,12 @@ task(:commits) do
   # ref, which is the common ancestor between the base branch and PR. Then do
   # git log for all of the commits in `HEAD` that are not in the base ref.
   github_base_ref = ENV.fetch('GITHUB_BASE_REF', 'main')
-  git_merge_base_cmd = ['git', 'merge-base', 'HEAD', github_base_ref]
+  github_base_ref = 'main' if github_base_ref.empty?
+  # There's still something odd here. After action/checkout, 'main' by itself raises
+  # objections from git like: `fatal: Not a valid object name main`.
+  # but 'origin/main' works. However, if github_base_ref were a sha,
+  # origin/SHA would fail as a reference...
+  git_merge_base_cmd = ['git', 'merge-base', 'HEAD', "origin/#{github_base_ref}"]
   baseref = run_command(git_merge_base_cmd)
   commits = "#{baseref}..HEAD"
   git_log_cmd = ['git', 'log', '--no-merges', '--pretty=%s', commits]

--- a/acceptance/GHA_ACCEPTANCE.md
+++ b/acceptance/GHA_ACCEPTANCE.md
@@ -1,0 +1,46 @@
+# Github Actions Acceptance Workflow
+
+[acceptance.yaml](.github/workflows/acceptance.yaml)
+
+This is a manual pipeline that can be triggered from the Actions tab
+of the GitHub repository. It runs the Beaker acceptance tests against
+either a pre-release build from
+https://artifacts.overlookinfratech.com, or released packages from the
+overlookinfratech.com repos.
+
+The pipeline makes use of nested virtualization to standup an agent
+of a given OS platform for the runner to run Beaker against. A matrix
+strategy builds out jobs for different os/version combinations.
+
+## Internals
+
+The workflow makes use of a composite action currently living in a
+Bolt module
+[kvm_automation_tooling](https://github.com/jpartlow/kvm_automation_tooling/blob/main/action.yaml).
+
+The action preps libvirt on the runner, installs Bolt and runs a
+[kvm_automation_tooling::standup_cluster](https://github.com/jpartlow/kvm_automation_tooling/blob/main/plans/standup_cluster.pp)
+plan which makes use of Terraform to generate a set of vms, set up
+ssh access and install the chose openvox-agent package.
+
+Then the workflow sets up ruby/beaker per the acceptance/Gemfile and
+runs another
+[kvm_automation_tooling::dev::generate_beaker_hosts_file](https://github.com/jpartlow/kvm_automation_tooling/blob/main/plans/dev/generate_beaker_hosts_file.pp)
+plan to set up the beaker hosts file. And then runs beaker.
+
+Note acceptance/Rakefile is not used in this workflow. That process
+relies on tasks provided by beaker-puppet which are tied to Perforce
+internals and repositories.
+
+Instead the kvm_automation_tooling plans installs openvox-agent
+packages using another Bolt module
+[openvox_bootstrap](https://github.com/jpartlow/openvox_bootstrap/).
+This module has an install task which servers the same purpose as the
+puppet_agent module install task: initial installation of the agent.
+The openvox_bootstrap module is configured to use the voxpupuli
+repositories.
+
+The module also has an
+[openvox_bootstrap::install_build_artifact](https://github.com/jpartlow/openvox_bootstrap/blob/main/tasks/install_build_artifact.json)
+task, which is what is used to install pre-release builds for testing
+in the pipeline.

--- a/acceptance/config/aio/options.rb
+++ b/acceptance/config/aio/options.rb
@@ -1,6 +1,3 @@
 {
   :type => 'aio',
-  :post_suite => [
-    'teardown/common/099_Archive_Logs.rb',
-  ],
 }

--- a/acceptance/pre-suite/configure_type_defaults.rb
+++ b/acceptance/pre-suite/configure_type_defaults.rb
@@ -1,0 +1,8 @@
+# Ensures that the /root/.ssh/environment file is
+# set up with a path that includes /opt/puppetlabs/bin.
+# Normally this would be called as part of beaker-puppet
+# install steps, but we are installing openvox-agent outside
+# of beaker-puppet, since it doesn't handle openvox.
+test_name('configure root ssh environment path') do
+  configure_type_defaults_on(agents)
+end

--- a/acceptance/tests/ensure_facter_command_can_be_executed.rb
+++ b/acceptance/tests/ensure_facter_command_can_be_executed.rb
@@ -2,10 +2,9 @@ test_name 'Ensure facter command can be executed' do
 
   require 'puppet/acceptance/common_utils'
 
-  facter =  agent['platform'] =~ /win/ ? 'cmd /c facter' : 'facter'
-
   agents.each do |agent|
     step "test facter command" do
+      facter =  agent['platform'] =~ /win/ ? 'cmd /c facter' : 'facter'
       on agent, "#{facter} --version", :acceptable_exit_codes => [0]
     end
   end


### PR DESCRIPTION
in a nested libvirt cluster. The host runner itself runs beaker against
a set of vms setup via the kvm_automation_tooling bolt module. That
module provides an action.yaml that wraps the libvirt setup and runs the
kvm_automation_tooling::standup_cluster plan.

After that we prep beaker and execute it against the agent nodes in the
new nested vm cluster.

This commit tears out the execution of the 'teardown/common/099_Archive_Logs.rb'
as part of the Beaker post_suite, since that step was only relevant
to jenkins.

It adds a presuite step used by the GHA action to run configure_type_defaults_on()
to get the .ssh/environment setup for beaker. Normally beaker-puppet
would do this, but it's not capable of installing openvox-agent, so the
standup_cluster plan is handling agent installation instead. The
configure_type_defaults_on() step is important because Beaker's use of
ssh as root relies on the .ssh/environment file supplying PATH to the
puppet binaries.

The kvm_automation_tooling module is only set up for ubuntu at the
moment. I'll need to do more work in that module to add platforms and
then the matrix can be expanded to match.