### PR TITLE
Add MacOS signing

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,9 +13,6 @@ jobs:
   rake_checks:
     name: Rake Checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        check: [ 'rubocop', 'commits' ]
     steps:
       - name: Checkout current PR
         uses: actions/checkout@v4
@@ -29,4 +26,4 @@ jobs:
         run: |
           gem update --system --silent --no-document
           bundle install --jobs 4 --retry 3
-      - run: bundle exec rake ${{ matrix.check }} --trace
+      - run: bundle exec rake rubocop --trace

--- a/tasks/build.rake
+++ b/tasks/build.rake
@@ -17,7 +17,12 @@ namespace :vox do
     engine = platform =~ /^(osx|windows)-/ ? 'local' : 'docker'
     cmd = "bundle exec build #{project} #{platform} --engine #{engine}"
 
-    FileUtils.rm_rf('C:/ProgramFiles64Folder') if platform =~ /^windows-/
+    if platform =~ /^windows-/
+      FileUtils.rm_rf('C:/ProgramFiles64Folder')
+    else
+      FileUtils.rm_rf('/opt/puppetlabs')
+      FileUtils.rm_rf('/etc/puppetlabs')
+    end
 
     run_command(cmd, silent: false, print_command: true, report_status: true)
   end


### PR DESCRIPTION
This utilizes [changes in Vanagon](https://github.com/OpenVoxProject/vanagon/pull/13) to enable signing locally, instead of shipping files to a signing server. Details for how to set this up given the appropriate certs/keys can be found on the wiki.

The vox:build task will sign the individual executables (puppet, pxp-agent, wrapper.sh) inside the package. The vox:sign task will sign the package inside the dmg, and then create a new dmg with the signed package in the "signed" directory.

This also removes the "commit" PR check, since we don't require adding ticket numbers or (maint) to each commit message like Perforce does.