### PR TITLE
(maint) Add debian 13 to acceptance testing.

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -58,6 +58,7 @@ jobs:
           - [debian, '10']
           - [debian, '11']
           - [debian, '12']
+          - [debian, '13', 'amd64', 'daily-latest']
     steps:
       - uses: actions/checkout@v4
         with:
@@ -67,7 +68,8 @@ jobs:
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}
-          os-arch: x86_64
+          os-arch: ${{ matrix.os[2] || 'x86_64' }}
+          image_version: ${{ matrix.os[3] }}
           host-root-access: true
           ruby-version: ${{ env.RUBY_VERSION }}
           install-openvox: true


### PR DESCRIPTION
Since debian-13 is not released yet, we need to provide image_version information so that the tooling can locate an image. 'daily-latest' will track the latest daily Debian 13 image build.