### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build openvox-agent
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/OpenVoxProject/openvox-agent/security/code-scanning/1](https://github.com/OpenVoxProject/openvox-agent/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow appears to be a build process, it likely only needs `contents: read` permissions to access repository files. If additional permissions are required for specific tasks (e.g., uploading artifacts or interacting with pull requests), they should be added explicitly.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
