### PR TITLE
(maint) Pin gha acceptance workflow to kvm_automation_tooling@v1

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: vm-cluster
-        uses: jpartlow/kvm_automation_tooling@main
+        uses: jpartlow/kvm_automation_tooling@v1
         with:
           os: ${{ matrix.os[0] }}
           os-version: ${{ matrix.os[1] }}


### PR DESCRIPTION
Pin to the floating v1 release tag for the kvm_automation_tooling module so that the workflow doesn't embrittle from unreleased changes on the main branch.