### PR TITLE
Gemfile: Remove Gemfile.local support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,3 @@ gem 'octokit'
 gem 'rubocop', "~> 1.22"
 gem 'rubocop-rake'
 gem 'github_changelog_generator'
-
-eval_gemfile("#{__FILE__}.local") if File.exist?("#{__FILE__}.local")


### PR DESCRIPTION
With the eval line, that we don't even use, dependabot errors out:

```
+-------------------------------------------------------------------------------------------------------------------------------------------------------+
|                                                                        Errors                                                                         |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
| Type                          | Details                                                                                                               |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
| dependency_file_not_parseable | {                                                                                                                     |
|                               |   "message": "Dependabot only supports uninterpolated string arguments to eval_gemfile. Got `\"#{__FILE__}.local\"`", |
|                               |   "file-path": "/Gemfile"                                                                                             |
|                               | }                                                                                                                     |
+-------------------------------+-----------------------------------------------------------------------------------------------------------------------+
```