### PR TITLE
Generate source artifacts

### DIFF
--- a/configs/projects/openvox-agent.rb
+++ b/configs/projects/openvox-agent.rb
@@ -1,6 +1,8 @@
 project 'openvox-agent' do |proj|
   platform = proj.get_platform
 
+  generate_source_artifacts true
+
   # puppet-agent inherits most build settings from openvoxproject/puppet-runtime:
   # - Modifications to global settings like flags and target directories should be made in puppet-runtime.
   # - Settings included in this file should apply only to local components in this repository.


### PR DESCRIPTION
This creates source RPMs, which can be useful if people want to inspect how it was built.

(cherry picked from commit 19c79225939854d800fb00983d0c2da40b1b7ff6)