### PR TITLE
(gh-64) Fix two acceptance tests for openvox7

### DIFF
--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -19,9 +19,15 @@ test_name 'Validate openssl version and fips' do
   agents.each do |agent|
     openssl = openssl_command(agent)
 
+    puppet_version = on(agent, puppet('--version')).stdout.chomp
+    expected_openssl = case puppet_version
+                       when /^7\./ then 1
+                       else 3
+                       end
+
     step "check openssl version" do
       on(agent, "#{openssl} version -v") do |result|
-        assert_match(/^OpenSSL 3\./, result.stdout)
+        assert_match(/^OpenSSL #{expected_openssl}\./, result.stdout)
       end
     end
 

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -21,7 +21,10 @@ def setup_build_environment(agent)
   # We add `--enable-system-libraries` to use system libsqlite3
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-  rubygems_version = agent['platform'] =~ /aix-7\.2/ ? '3.4.22' : ''
+
+  puppet_version = on(agent, puppet('--version')).stdout.chomp
+  rubygems_version = ((agent['platform'] =~ /aix-7\.2/) ||
+                      (puppet_version =~ /^7\./)) ? '3.4.22' : ''
   on(agent, "#{gem_command(agent)} update --system #{rubygems_version}")
 
   case agent['platform']


### PR DESCRIPTION
The validate_vendored_openssl and validate_vendored_ruby tests were failing when run against openvox7. The openssl test was expecting openssl 3 instead of the v1 shipped with openvox7. And the ruby test was attempting a gem update --system which was pulling the latest rubygem-update which is incompatible with the ruby 2.7 shipped with openvox7.

Presumably the suite was never run for the puppet 7 collection, or I'm missing something else -- or these tests were specifically skipped?

Either way, it was simple enough to add a version test for these two, allowing them to pass by testing for openssl v1, and tightening up the gem update --system to 3.4.22 which was the last rubygems available for ruby 2.7.