### PR TITLE
(gh-64) Fix two acceptance tests for openvox7

### DIFF
--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -1,0 +1,77 @@
+require 'puppet/acceptance/temp_file_utils'
+
+test_name 'Validate openssl version and fips' do
+  extend Puppet::Acceptance::TempFileUtils
+
+  tag 'audit:high'
+
+  def openssl_command(host)
+    puts "privatebindir=#{host['privatebindir']}"
+    "env PATH=\"#{host['privatebindir']}:${PATH}\" openssl"
+  end
+
+  def create_bat_wrapper(host, file, command)
+    tempfile = get_test_file_path(agent, file)
+    create_remote_file(agent, tempfile, command)
+    "cmd /c $(cygpath -w #{tempfile})"
+  end
+
+  agents.each do |agent|
+    openssl = openssl_command(agent)
+
+    puppet_version = on(agent, puppet('--version')).stdout.chomp
+    expected_openssl = case puppet_version
+                       when /^7\./ then 1
+                       else 3
+                       end
+
+    step "check openssl version" do
+      on(agent, "#{openssl} version -v") do |result|
+        assert_match(/^OpenSSL #{expected_openssl}\./, result.stdout)
+      end
+    end
+
+    if agent['template'] =~ /fips/
+      step "check fips_enabled fact" do
+        on(agent, facter("fips_enabled")) do |result|
+          assert_match(/^true/, result.stdout)
+        end
+      end
+
+      step "check openssl providers" do
+        if agent['template'] =~ /^win/
+          list_command = create_bat_wrapper(agent, "list_providers.bat", <<~END)
+          call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" %0 %*
+          openssl list -providers
+          END
+        else
+          list_command = "#{openssl} list -providers"
+        end
+
+        on(agent, list_command) do |result|
+          assert_match(Regexp.new(<<~END, Regexp::MULTILINE), result.stdout)
+          \s*fips
+          \s*name: OpenSSL FIPS Provider
+          \s*version: 3.0.9
+          \s*status: active
+          END
+        end
+      end
+
+      step "check fipsmodule.cnf" do
+        if agent['template'] =~ /^win/
+          verify_command = create_bat_wrapper(agent, "verify_fips.bat", <<~END)
+          call "C:\\Program Files\\Puppet Labs\\Puppet\\bin\\environment.bat" %0 %*
+          openssl fipsinstall -module "%OPENSSL_MODULES%\\fips.dll" -provider_name fips -in "%OPENSSL_CONF_INCLUDE%\\fipsmodule.cnf" -verify
+          END
+        else
+          verify_command = "#{openssl} fipsinstall -module /opt/puppetlabs/puppet/lib/ossl-modules/fips.so -provider_name fips -in /opt/puppetlabs/puppet/ssl/fipsmodule.cnf -verify"
+        end
+
+        on(agent, verify_command) do |result|
+          assert_match(/VERIFY PASSED/, result.stderr)
+        end
+      end
+    end
+  end
+end

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -28,7 +28,11 @@ def setup_build_environment(agent)
   # Pin to 1.6.9 which was the last version to support "native gem support for 2.7"
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -v 1.6.9 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-  on(agent, "#{gem_command(agent)} update --system 3.4.22")
+
+  puppet_version = on(agent, puppet('--version')).stdout.chomp
+  rubygems_version = ((agent['platform'] =~ /aix-7\.2/) ||
+                      (puppet_version =~ /^7\./)) ? '3.4.22' : ''
+  on(agent, "#{gem_command(agent)} update --system #{rubygems_version}")
 
   case agent['platform']
   when /aix/


### PR DESCRIPTION
The validate_vendored_openssl and validate_vendored_ruby tests were failing when run against openvox7. The openssl test was expecting openssl 3 instead of the v1 shipped with openvox7. And the ruby test was attempting a gem update --system which was pulling the latest rubygem-update which is incompatible with the ruby 2.7 shipped with openvox7.

Presumably the suite was never run for the puppet 7 collection, or I'm missing something else -- or these tests were specifically skipped?

Either way, it was simple enough to add a version test for these two, allowing them to pass by testing for openssl v1, and tightening up the gem update --system to 3.4.22 which was the last rubygems available for ruby 2.7.

(cherry picked from commit 5b94b5f3cdf76e97880172b2a488524b41f43d08)