### PR TITLE
Gh 64 revert pr 65

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -31,7 +31,12 @@ on:
         description: '(Version) Package version to test. (required if Pre-release Build is true)'
         type: string
       collection:
-        description: '(Collection) OpenVox collection to use. (ignored if Pre-release Build is true)'
+        description: |-
+          (Collection) OpenVox collection to use. (ignored if Pre-release Build is true)
+
+          NOTE: This should really only be set to openvox8 when
+          testing the main branch. If you need to test openvox7, you
+          should run the pipeline from the 7.x branch instead.
         default: 'openvox8'
         type: string
       artifacts-url:

--- a/acceptance/tests/validate_vendored_openssl.rb
+++ b/acceptance/tests/validate_vendored_openssl.rb
@@ -19,15 +19,9 @@ test_name 'Validate openssl version and fips' do
   agents.each do |agent|
     openssl = openssl_command(agent)
 
-    puppet_version = on(agent, puppet('--version')).stdout.chomp
-    expected_openssl = case puppet_version
-                       when /^7\./ then 1
-                       else 3
-                       end
-
     step "check openssl version" do
       on(agent, "#{openssl} version -v") do |result|
-        assert_match(/^OpenSSL #{expected_openssl}\./, result.stdout)
+        assert_match(/^OpenSSL 3\./, result.stdout)
       end
     end
 

--- a/acceptance/tests/validate_vendored_ruby.rb
+++ b/acceptance/tests/validate_vendored_ruby.rb
@@ -21,10 +21,7 @@ def setup_build_environment(agent)
   # We add `--enable-system-libraries` to use system libsqlite3
   gem_install_sqlite3 = "env GEM_HOME=/opt/puppetlabs/puppet/lib/ruby/vendor_gems " + gem_command(agent) + " install sqlite3 -- --enable-system-libraries"
   install_package_on_agent = package_installer(agent)
-
-  puppet_version = on(agent, puppet('--version')).stdout.chomp
-  rubygems_version = ((agent['platform'] =~ /aix-7\.2/) ||
-                      (puppet_version =~ /^7\./)) ? '3.4.22' : ''
+  rubygems_version = agent['platform'] =~ /aix-7\.2/ ? '3.4.22' : ''
   on(agent, "#{gem_command(agent)} update --system #{rubygems_version}")
 
   case agent['platform']


### PR DESCRIPTION
This reverts commit https://github.com/OpenVoxProject/openvox-agent/commit/749850f7160998299daad1c9f6783a1da0c104bf, reversing
changes made to https://github.com/OpenVoxProject/openvox-agent/commit/9eada289f5b03621c9e5d157af12e274627ed4a3.

I'd forgotten about the 7.x branch which has the correct tests for
openvox7. Have backported the testing pipeline to 7.x in #68,
and am reverting the conditional openvox7 changes to the main suite here,
which should really only be testing openvox8 atm.

Also added a note to the collection parameter in the acceptance workflow.