### PR TITLE
puppet-runtime: Fix artifacts url

### DIFF
--- a/configs/components/puppet-runtime.json
+++ b/configs/components/puppet-runtime.json
@@ -1,1 +1,1 @@
-{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/202507081/","version":"202507082"}
+{"location":"https://s3.osuosl.org/openvox-artifacts/puppet-runtime/202507082/","version":"202507082"}


### PR DESCRIPTION
We mixed two versions in the URL, which results in a HTTP 404

```
Error contacting ***/***/puppet-runtime/202507081/agent-runtime-main-202507082.amazon-2-aarch64.settings.yaml
```