### PR TITLE
OpenVox: Remove build dependency to facter

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -2,7 +2,6 @@ component "puppet" do |pkg, settings, platform|
   pkg.load_from_json("configs/components/puppet.json")
 
   pkg.build_requires "puppet-runtime" # Provides ruby and rubygem-win32-dir
-  pkg.build_requires "facter"
 
   # Used to compile binary translation files
   # i18n is not supported on Solaris


### PR DESCRIPTION
This isn't needed anymore since https://github.com/OpenVoxProject/openvox/pull/147