### PR TITLE
Stop passing --[no-]check-prereqs to install.rb

### DIFF
--- a/configs/components/puppet.rb
+++ b/configs/components/puppet.rb
@@ -122,21 +122,18 @@ component "puppet" do |pkg, settings, platform|
     configdir = File.join(settings[:sysconfdir], 'puppet', 'etc')
     logdir = File.join(settings[:sysconfdir], 'puppet', 'var', 'log')
     piddir = File.join(settings[:sysconfdir], 'puppet', 'var', 'run')
-    prereqs = "--check-prereqs"
   else
     vardir = File.join(settings[:prefix], 'cache')
     publicdir = File.join(settings[:prefix], 'public')
     configdir = settings[:puppet_configdir]
     logdir = settings[:logdir]
     piddir = settings[:piddir]
-    prereqs = "--no-check-prereqs"
   end
 
   pkg.install do
     [
       "#{settings[:host_ruby]} install.rb \
         --ruby=#{File.join(settings[:bindir], 'ruby')} \
-        #{prereqs} \
         --bindir=#{settings[:bindir]} \
         --configdir=#{configdir} \
         --sitelibdir=#{settings[:ruby_vendordir]} \


### PR DESCRIPTION
This option has been dropped and passing it stops it from respecting any option.

Copying https://github.com/OpenVoxProject/openvox-agent/actions/runs/16178134004/job/45668117846#step:6:1009

> install: invalid option: --no-check-prereqs

It then starts to install into `/opt/puppetlabs/puppet/lib/ruby/site_ruby/3.2.0/puppet`.

Link: https://github.com/OpenVoxProject/openvox/commit/b909b673bae784af7822fcd58549fd6773b4320b