### PR TITLE
Promote puppet to 8.21.0->8.21.1

### DIFF
--- a/configs/components/puppet.json
+++ b/configs/components/puppet.json
@@ -1,1 +1,1 @@
-{"url":"https://github.com/openvoxproject/openvox.git","ref":"3cb7ae5d52f294394cdca4f4b2e29cae080633d2"}
+{"url":"https://github.com/openvoxproject/openvox.git","ref":"72de3266ea4c6867220f4069284dd0aea2d92a3b"}


### PR DESCRIPTION
This promotes the puppet (openvox) component to 8.21.1

https://github.com/OpenVoxProject/openvox/commit/72de3266ea4c6867220f4069284dd0aea2d92a3b