### PR TITLE
Correct provides statement for Debian packaging

### DIFF
--- a/configs/projects/openvox-agent.rb
+++ b/configs/projects/openvox-agent.rb
@@ -160,11 +160,7 @@ project 'openvox-agent' do |proj|
   # make sure we can replace puppet-agent in place for the rename
   proj.replaces 'puppet-agent', "< #{major.to_i + 1}"
   proj.conflicts 'puppet-agent'
-  if platform.is_rpm?
-    proj.provides 'puppet-agent', "= #{major}"
-  elsif platform.is_deb?
-    proj.provides 'puppet-agent', "(= #{major})"
-  end
+  proj.provides 'puppet-agent', "= #{major}"
 
   proj.timeout 7200 if platform.is_windows?
 end


### PR DESCRIPTION
In 83d06f38a68eb128e45ad1cf5fd2db35d56aec2f I tried to add a proper provides, but it turns out Vanagon completely ignores any version constraint. Once it does, it shouldn't need the braces around it. Then it's the same as RPM and the code can be simplified.

This is needed for https://github.com/OpenVoxProject/vanagon/pull/51.