### PR TITLE
Changes for building Windows agents in GitHub Actions

### DIFF
--- a/configs/platforms/windows-all-x64.rb
+++ b/configs/platforms/windows-all-x64.rb
@@ -1,4 +1,4 @@
-platform "windows-2019-x64" do |plat|
+platform "windows-all-x64" do |plat|
   plat.vmpooler_template "win-2019-x86_64"
   plat.servicetype 'windows'
 

--- a/resources/windows/wix/service.puppet.wxs.erb
+++ b/resources/windows/wix/service.puppet.wxs.erb
@@ -3,10 +3,10 @@
 
   <Fragment>
 
-    <ComponentGroup Id="<%= get_service("openvox").component_group_id %>">
+    <ComponentGroup Id="<%= get_service("puppet").component_group_id %>">
       <Component Id='PuppetServiceAutomatic'
                  Guid="639ECD7F-6186-43D5-9E1A-FC0278DBEE15"
-                 Directory="<%= get_service("openvox").bindir_id %>"
+                 Directory="<%= get_service("puppet").bindir_id %>"
                  Win64="<%= settings[:win64] %>">
         <Condition>
           <![CDATA[ (PUPPET_AGENT_STARTUP_MODE ~<> "manual") AND (PUPPET_AGENT_STARTUP_MODE ~<> "disabled") ]]>
@@ -37,7 +37,7 @@
 
       <Component Id='PuppetServiceManual'
                  Guid="752A5A25-9619-4EBA-AA8B-12D8C8688236"
-                 Directory="<%= get_service("openvox").bindir_id %>"
+                 Directory="<%= get_service("puppet").bindir_id %>"
                  Win64="<%= settings[:win64] %>">
         <Condition>
           <![CDATA[PUPPET_AGENT_STARTUP_MODE ~= "manual"]]>
@@ -67,7 +67,7 @@
 
       <Component Id='PuppetServiceDisabled'
                  Guid="4D3A8CAF-C675-46AC-B3AD-75F00581D0DB"
-                 Directory="<%= get_service("openvox").bindir_id %>"
+                 Directory="<%= get_service("puppet").bindir_id %>"
                  Win64="<%= settings[:win64] %>">
         <Condition>
           <![CDATA[PUPPET_AGENT_STARTUP_MODE ~= "disabled"]]>

--- a/setup.bat
+++ b/setup.bat
@@ -1,1 +1,1 @@
-C:\setup-x86_64.exe -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel
+C:\setup-x86_64.exe -s https://cygwin.osuosl.org -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel

--- a/setup.bat
+++ b/setup.bat
@@ -1,1 +1,0 @@
-C:\setup-x86_64.exe -s https://cygwin.osuosl.org -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,0 +1,9 @@
+$url="https://github.com/wixtoolset/wix3/releases/download/wix3141rtm/wix314.exe"
+$dest="C:\wix314.exe"
+Invoke-WebRequest -Uri $url -OutFile $dest
+cmd /c "C:\wix314.exe -quiet"
+
+$url="https://cygwin.com/setup-x86_64.exe"
+$dest="C:\setup-x86_64.exe"
+Invoke-WebRequest -Uri $url -OutFile $dest
+cmd /c "C:\setup-x86_64.exe -s https://cygwin.osuosl.org -q -P ruby,ruby-devel,gcc-core,make,git,libyaml-devel"


### PR DESCRIPTION
This changes the platform name to `windows-all-x64` to better reflect it is an agent for all supported Windows platforms, moves setup into setup.ps1, fixes the upload task, and finishes an incomplete revert from when we tried changing the puppet component to openvox previously.